### PR TITLE
Include dash-functional library

### DIFF
--- a/helm-switch-frame.el
+++ b/helm-switch-frame.el
@@ -33,6 +33,7 @@
 
 (require 'helm)
 (require 'dash)
+(require 'dash-functional)
 
 (defun hsf/switch-to-frame (frame-name)
   (select-frame-set-input-focus (cdr (assoc frame-name (hsf/frame-names-with-frame)))))


### PR DESCRIPTION
The -on function is only available in the dash-functional library. If it isn't included, you get a symbol function definition is void error after enabling projectile mode and using helm-switch-frame.
